### PR TITLE
Display a special message when the total number of matches is unknown.

### DIFF
--- a/js/controls/UserPicker.js
+++ b/js/controls/UserPicker.js
@@ -63,6 +63,9 @@ define([
                         header.text('No matches');
                         widget.popup.open();
                     }
+                    else if (dataSource.total() < 0) {
+                        header.text('All Users (100+ matches)');
+                    }
                     else {
                         header.text(kendo.format('All Users ({0:n0} matches)', dataSource.total()));
                     }


### PR DESCRIPTION
When the query is so broad, the service will return a totalCount of -1. Instead of showing "(-1 matches)", show something more accurate. In this case, the server sends -1 when there are more than 100 matches.
