### PR TITLE
Small tweaks to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # wingspan-forms
-
 > a dynamic form library for Facebook React, providing abstractions for building dynamic forms with validation. Widgets provided by [Telerik's KendoUI](http://www.telerik.com/kendo-ui).
 
 [![example form screenshot & jsfiddle](docs/_assets/simple-form.png?raw=true)](http://jsfiddle.net/dustingetz/84JuE/12/)


### PR DESCRIPTION
Main change was a small tweak to the `Examples` header.  I believe this library sells itself as long as people click on the examples.  Hopefully this simple change leads to more people actually clicking on the links to try out the examples!

Also fixed a minor typo.
