### PR TITLE
Removed dependency on moment.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -81,7 +81,6 @@ module.exports = function (grunt) {
                     'underscore-string': { exports: ['_s'] },
                     'jquery': { deps: [], exports: '$' },
                     'kendo': { deps: [], exports: 'kendo' },
-                    'moment': { deps: [], exports: 'moment' },
                     'react': { deps: [], exports: 'React'}
                 },
 
@@ -98,8 +97,7 @@ module.exports = function (grunt) {
                 options: {
                     out: 'dist/wingspan-forms.js',
                     include: ['almond', 'wingspan-forms'],
-                    exclude: ['jquery', 'underscore', 'react', 'moment', 'require',
-                        'text', 'underscore-string', 'kendo']
+                    exclude: ['jquery', 'underscore', 'react', 'require', 'text', 'underscore-string', 'kendo']
                 }
             },
             compileQuickStart: {

--- a/almond-begin.txt
+++ b/almond-begin.txt
@@ -1,9 +1,9 @@
 (function (root, factory) {
     if (typeof define === 'function' && define.amd) {
         define([
-            'underscore', 'react', 'jquery', 'moment', 'underscore-string', 'kendo', 'text'
+            'underscore', 'react', 'jquery', 'underscore-string', 'kendo', 'text'
         ], factory);
     } else {
-        root.WingspanForms = factory(root._, root.React, root.$, root.moment, root._s, root.kendo);
+        root.WingspanForms = factory(root._, root.React, root.$, root._s, root.kendo);
     }
-}(this, function (_, React, $, moment, _s, kendo) {
+}(this, function (_, React, $, _s, kendo) {

--- a/almond-end.txt
+++ b/almond-end.txt
@@ -3,7 +3,6 @@
     define('underscore', function () { return _; });
     define('react', function () { return React; });
     define('jquery', function () { return $; });
-    define('moment', function () { return moment; });
     define('underscore-string', function () { return _s; });
     define('kendo', function () { return kendo; });
     define('text', function () { return undefined; });

--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,6 @@
   ],
   "dependencies": {
     "jquery": "~1.9.1",
-    "momentjs": "~2.0",
     "underscore": "~1.4.4",
     "react": "~0.8",
     "requirejs": "~2.1.9",

--- a/js/controls/KendoDate.js
+++ b/js/controls/KendoDate.js
@@ -1,9 +1,9 @@
 /** @jsx React.DOM */
 define([
-    'underscore', 'jquery', 'react', 'kendo', 'moment',
+    'underscore', 'jquery', 'react', 'kendo',
     '../util/debug',
     '../ControlCommon'
-], function (_, $, React, kendo, moment, debug, ControlCommon) {
+], function (_, $, React, kendo, debug, ControlCommon) {
     'use strict';
 
 
@@ -13,6 +13,7 @@ define([
 
         getDefaultProps: function () {
             return {
+                format: 'dd-MMM-yyyy',
                 value: undefined,
                 id: undefined,
                 onChange: function () {},
@@ -26,7 +27,7 @@ define([
         /*jshint ignore:start */
         render: function () {
             return (this.props.noControl
-                ? (<span>{this.props.value ? moment(this.props.value).format('DD-MMM-YYYY') : ''}</span>)
+                ? (<span>{this.props.value ? kendo.toString(this.props.value, this.props.format) : ''}</span>)
                 : (<input id={this.props.id} type="text" />));
         },
         /*jshint ignore:end */
@@ -44,7 +45,7 @@ define([
 
             $el.kendoDatePicker({
                 change: this.onChange,
-                format: 'dd-MMM-yyyy'
+                format: this.props.format
             });
 
             ControlCommon.setKendoDateState(

--- a/js/controls/KendoDatetime.js
+++ b/js/controls/KendoDatetime.js
@@ -1,9 +1,9 @@
 /** @jsx React.DOM */
 define([
-    'underscore', 'jquery', 'react', 'kendo', 'moment',
+    'underscore', 'jquery', 'react', 'kendo',
     '../util/debug',
     '../ControlCommon'
-], function (_, $, React, kendo, moment, debug, ControlCommon) {
+], function (_, $, React, kendo, debug, ControlCommon) {
     'use strict';
 
 
@@ -27,7 +27,7 @@ define([
         /*jshint ignore:start */
         render: function () {
             return (this.props.noControl
-                ? (<span>{this.props.value ? moment(this.props.value).format('MMMM Do YYYY, h:mm:ss a') : ''}</span>)
+                ? (<span>{this.props.value ? kendo.toString(this.props.value, this.props.format) : ''}</span>)
                 : (<input id={this.props.id} type="text" />));
         },
         /*jshint ignore:end */

--- a/js/util/util.js
+++ b/js/util/util.js
@@ -1,7 +1,7 @@
 define([
-    'underscore', 'jquery', 'moment',
+    'underscore', 'jquery', 'kendo',
     './debug'
-], function (_, $, moment, debug) {
+], function (_, $, kendo, debug) {
     'use strict';
 
     var exports = {};
@@ -109,11 +109,11 @@ define([
 
         // TODO DATE NEEDS TO COME FROM SERVER CONFIGURATION
         if ('datetime' === dataType && _.isString(value)) {
-            return moment(value).format('DD-MMM-YYYY h:mm:ss A');
+            return kendo.toString(value, 'dd-MMM-yyyy h:mm tt');
         }
         // todo need to be able to handle date only fields here
         if ('date' === dataType && _.isString(value)) {
-            return moment(value).format('DD-MMM-YYYY');
+            return kendo.toString(value, 'dd-MMM-yyyy');
         }
 
         // so it's a complex object, and we'll just try to sort it out at the moment


### PR DESCRIPTION
Since kendo is formatting dates in the live widgets, it is best to use
it to format dates in “noControl” modes as well. It also "lightens" the library somewhat.
